### PR TITLE
Better syntax for Eithers

### DIFF
--- a/pact_test/either/__init__.py
+++ b/pact_test/either/__init__.py
@@ -5,6 +5,12 @@ class Either(object):
     def __init__(self, value):
         self.value = value
 
+    def __rshift__(self, f):
+        if type(self) is Right:
+            return f(self.value)
+        else:
+            return self
+
     def concat(self, f, *args):
         if type(self) is Right:
             return f(self.value, *args)

--- a/tests/either/test_either.py
+++ b/tests/either/test_either.py
@@ -12,17 +12,17 @@ def test_right_value():
 
 
 def test_concat_right():
-    out = minus_one(45).concat(minus_one).concat(minus_one)
+    out = minus_one(45) >> minus_one >> minus_one
     assert out.value == 42
 
 
 def test_concat_left():
-    out = minus_one(1).concat(one_divided_by)
+    out = minus_one(1) >> one_divided_by
     assert out.value == "Division by zero."
 
 
 def test_break_the_chain():
-    out = minus_one(1).concat(one_divided_by).concat(minus_one)
+    out = minus_one(1) >> one_divided_by >> minus_one
     assert out.value == "Division by zero."
 
 


### PR DESCRIPTION
Either class overrides `__rshift__` magic method to allow the usage of `>>` to cancatenate several functions. Example:

```python
def test_break_the_chain():
    out = minus_one(1) >> one_divided_by >> minus_one
    assert out.value == "Division by zero."
```

The `concat` function remains to allow the concatenation of functions that require more than one input parameter. Example:

```python
def test_multiple_parameters():
    out = minus_one(9).concat(my_sum, 5)
    assert out.value == 13

def my_sum(a, b):
    return Right(a + b)
```