### PR TITLE
Fix Docker :whale: test

### DIFF
--- a/tests/environments/Dockerfilepy27
+++ b/tests/environments/Dockerfilepy27
@@ -5,3 +5,4 @@ WORKDIR /app
 ADD requirements.txt /app
 RUN pip install -r requirements.txt
 ADD . /app
+RUN find . -name '*.pyc' -delete

--- a/tests/environments/Dockerfilepy33
+++ b/tests/environments/Dockerfilepy33
@@ -5,3 +5,4 @@ WORKDIR /app
 ADD requirements.txt /app
 RUN pip install -r requirements.txt
 ADD . /app
+RUN find . -name '*.pyc' -delete

--- a/tests/environments/Dockerfilepy34
+++ b/tests/environments/Dockerfilepy34
@@ -5,3 +5,4 @@ WORKDIR /app
 ADD requirements.txt /app
 RUN pip install -r requirements.txt
 ADD . /app
+RUN find . -name '*.pyc' -delete

--- a/tests/environments/Dockerfilepy35
+++ b/tests/environments/Dockerfilepy35
@@ -5,3 +5,4 @@ WORKDIR /app
 ADD requirements.txt /app
 RUN pip install -r requirements.txt
 ADD . /app
+RUN find . -name '*.pyc' -delete

--- a/tests/environments/Dockerfilepy36
+++ b/tests/environments/Dockerfilepy36
@@ -5,3 +5,4 @@ WORKDIR /app
 ADD requirements.txt /app
 RUN pip install -r requirements.txt
 ADD . /app
+RUN find . -name '*.pyc' -delete


### PR DESCRIPTION
Remove all `.pyc` files in containers before running tests to avoid "_confusion_" in PyTest discovery.